### PR TITLE
Support setting http.Server properties through config.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "koa-simple-web",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "koa-simple-web",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"description": "A simple web server using Koa",
 	"main": "src/simple-web.js",
 	"scripts": {

--- a/src/simple-web.js
+++ b/src/simple-web.js
@@ -2,9 +2,23 @@
 
 const Koa = require("koa");
 
+const PASSTHROUGH_CONFIG_KEYS = [
+	"maxHeadersCount",
+	"headersTimeout",
+	"timeout",
+	"keepAliveTimeout"
+];
+
 /**
  * @typedef {Object} SimpleWebServerConfig
+ *
+ * See this bug related to the timeouts: https://github.com/nodejs/node/issues/27363
+ *
  * @property {number} port The port to listen on
+ * @property [number] maxHeadersCount {@link https://nodejs.org/docs/latest/api/http.html#http_server_maxheaderscount}
+ * @property [number] headersTimeout {@link https://nodejs.org/docs/latest/api/http.html#http_server_headerstimeout}
+ * @property [number] timeout {@link https://nodejs.org/docs/latest/api/http.html#http_server_timeout}
+ * @property [number] keepAliveTimeout {@link https://nodejs.org/docs/latest/api/http.html#http_server_keepalivetimeout}
  */
 
 /**
@@ -27,6 +41,13 @@ class SimpleWeb {
 		return new Promise((resolve, reject) => {
 			if (!this._server) {
 				this._server = this._web.listen(this._config.port);
+
+				PASSTHROUGH_CONFIG_KEYS.forEach((key) => {
+					if (typeof this._config[key] !== 'undefined') {
+						this._server[key] = this._config[key];
+					}
+				});
+
 				this._server.on("listening", resolve);
 			}
 			else {


### PR DESCRIPTION
There are some http.Server properties that are useful to be able to set as part of the configuration of the server. This allows you to put the properties on the config object passed to the SimpleWeb constructor to set the corresponding keys on the Server instance.

One reason this can be useful is if your application is behind a load balancer: your app's keepAliveTimeout should be greater than your load balancer's idle timeout.

Another reason this is useful is to work around bug https://github.com/nodejs/node/issues/27363 (In short, make your headersTimeout greater than your keepAliveTimeout.)